### PR TITLE
Updates to avoid CVE-2021-34552, CVE-2021-25287, CVE-2021-25288, CVE-2020-10994

### DIFF
--- a/j5_build_instructions.txt
+++ b/j5_build_instructions.txt
@@ -1,6 +1,6 @@
 Follow the steps in winbuild.rst with the following adustments:
 1. If the downloading of the dependencies fails, adjust the requests call to add header to stop it getting blocked as a blob.
-3. Install Visual Studio C++ extension for 9.0, 1.0, 12.0 and 14.0 (TBC which are actually required)
+3. Install Visual Studio C++ extension for 9.0, 10.0, 12.0 and 14.0 (TBC which are actually required)
 5. After running `build_deps.py`, which will fail, - adjust build-deps.cmd batch script with the following:
     - add "set VCTargetsPath=C:\Program Files (x86)\MSBuild\Microsoft.Cpp\4.0\V140" on line 14
     - change "v7.0" to "v7.1" on line 26 (now 27) for the SetEnv.cmd file

--- a/j5_build_instructions.txt
+++ b/j5_build_instructions.txt
@@ -1,0 +1,6 @@
+Follow the steps in winbuild.rst with the following adustments:
+1. If the downloading of the dependencies fails, adjust the requests call to add header to stop it getting blocked as a blob.
+3. Install Visual Studio C++ extension for 9.0, 1.0, 12.0 and 14.0 (TBC which are actually required)
+5. After running `build_deps.py`, which will fail, - adjust build-deps.cmd batch script with the following:
+    - add "set VCTargetsPath=C:\Program Files (x86)\MSBuild\Microsoft.Cpp\4.0\V140" on line 14
+    - change "v7.0" to "v7.1" on line 26 (now 27) for the SetEnv.cmd file

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = "6.2.2"
+__version__ = "6.2.2+j5"

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1622,12 +1622,9 @@ convert(Imaging imOut, Imaging imIn, const char *mode,
 #ifdef notdef
         return (Imaging) ImagingError_ValueError("conversion not supported");
 #else
-    {
-      static char buf[256];
-      /* FIXME: may overflow if mode is too large */
-      sprintf(buf, "conversion from %s to %s not supported", imIn->mode, mode);
-      return (Imaging) ImagingError_ValueError(buf);
-    }
+        static char buf[100];
+        sprintf(buf, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
+        return (Imaging)ImagingError_ValueError(buf);
 #endif
 
     imOut = ImagingNew2Dirty(mode, imOut, imIn);
@@ -1681,10 +1678,13 @@ ImagingConvertTransparent(Imaging imIn, const char *mode,
     }
 #else
     {
-      static char buf[256];
-      /* FIXME: may overflow if mode is too large */
-      sprintf(buf, "conversion from %s to %s not supported in convert_transparent", imIn->mode, mode);
-      return (Imaging) ImagingError_ValueError(buf);
+        static char buf[100];
+        sprintf(
+            buf,
+            "conversion from %.10s to %.10s not supported in convert_transparent",
+            imIn->mode,
+            mode);
+        return (Imaging)ImagingError_ValueError(buf);
     }
 #endif
 

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1623,7 +1623,7 @@ convert(Imaging imOut, Imaging imIn, const char *mode,
         return (Imaging) ImagingError_ValueError("conversion not supported");
 #else
         static char buf[100];
-        sprintf(buf, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
+        snprintf(buf, 100, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
         return (Imaging)ImagingError_ValueError(buf);
 #endif
 
@@ -1679,8 +1679,9 @@ ImagingConvertTransparent(Imaging imIn, const char *mode,
 #else
     {
         static char buf[100];
-        sprintf(
+        snprintf(
             buf,
+            100,
             "conversion from %.10s to %.10s not supported in convert_transparent",
             imIn->mode,
             mode);

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1622,9 +1622,11 @@ convert(Imaging imOut, Imaging imIn, const char *mode,
 #ifdef notdef
         return (Imaging) ImagingError_ValueError("conversion not supported");
 #else
-        static char buf[100];
-        snprintf(buf, 100, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
-        return (Imaging)ImagingError_ValueError(buf);
+    {
+      static char buf[100];
+      snprintf(buf, 100, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
+      return (Imaging)ImagingError_ValueError(buf);
+    }
 #endif
 
     imOut = ImagingNew2Dirty(mode, imOut, imIn);

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -158,19 +158,6 @@ def main(op):
             )
         )
 
-        scripts.append(
-            (
-                "%s%s" % (py_version, X64_EXT),
-                "\n".join(
-                    [
-                        header(op),
-                        build_one("%sx64" % py_version, py_compilers[64], 64),
-                        footer(),
-                    ]
-                ),
-            )
-        )
-
     results = map(run_script, scripts)
 
     for (version, status, trace, err) in results:

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -111,9 +111,9 @@ def build_one(py_ver, compiler, bit):
         args["tcl_ver"] = "86"
 
     if compiler["vc_version"] == "2015":
-        args["imaging_libs"] = " build_ext --add-imaging-libs=msvcrt"
+        args["imaging_libs"] = " build_ext --disable-jpeg2000 --add-imaging-libs=msvcrt"
     else:
-        args["imaging_libs"] = ""
+        args["imaging_libs"] = "build_ext --disable-jpeg2000"
 
     args["vc_setup"] = vc_setup(compiler, bit)
 

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -5,12 +5,12 @@ GITHUB_DEPENDS_URL = "https://github.com/python-pillow/pillow-depends/blob/maste
 
 pythons = {
     "27": {"compiler": 7, "vc": 2010},
-    "pypy2": {"compiler": 7, "vc": 2010},
-    "35": {"compiler": 7.1, "vc": 2015},
-    "36": {"compiler": 7.1, "vc": 2015},
-    "pypy3": {"compiler": 7.1, "vc": 2015},
-    "37": {"compiler": 7.1, "vc": 2015},
-    "38": {"compiler": 7.1, "vc": 2015},
+    # "pypy2": {"compiler": 7, "vc": 2010},
+    # "35": {"compiler": 7.1, "vc": 2015},
+    # "36": {"compiler": 7.1, "vc": 2015},
+    # "pypy3": {"compiler": 7.1, "vc": 2015},
+    # "37": {"compiler": 7.1, "vc": 2015},
+    # "38": {"compiler": 7.1, "vc": 2015},
 }
 
 VIRT_BASE = "c:/vp/"

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -1,7 +1,7 @@
 import os
 
-SF_MIRROR = "http://iweb.dl.sourceforge.net"
 PILLOW_DEPENDS_DIR = "C:\\pillow-depends\\"
+GITHUB_DEPENDS_URL = "https://github.com/python-pillow/pillow-depends/blob/master/"
 
 pythons = {
     "27": {"compiler": 7, "vc": 2010},
@@ -32,7 +32,7 @@ libs = {
         "dir": "jpeg-9c",
     },
     "tiff": {
-        "url": "ftp://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz",
+        "url": "https://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz",
         "filename": PILLOW_DEPENDS_DIR + "tiff-4.0.10.tar.gz",
         "dir": "tiff-4.0.10",
     },
@@ -42,7 +42,7 @@ libs = {
         "dir": "freetype-2.10.1",
     },
     "lcms": {
-        "url": SF_MIRROR + "/project/lcms/lcms/2.7/lcms2-2.7.zip",
+        "url": GITHUB_DEPENDS_URL + "lcms2-2.7.zip",
         "filename": PILLOW_DEPENDS_DIR + "lcms2-2.7.zip",
         "dir": "lcms2-2.7",
     },
@@ -52,23 +52,23 @@ libs = {
         "dir": "ghostscript-9.27",
     },
     "tcl-8.5": {
-        "url": SF_MIRROR + "/project/tcl/Tcl/8.5.19/tcl8519-src.zip",
+        "url": GITHUB_DEPENDS_URL + "tcl8519-src.zip",
         "filename": PILLOW_DEPENDS_DIR + "tcl8519-src.zip",
         "dir": "",
     },
     "tk-8.5": {
-        "url": SF_MIRROR + "/project/tcl/Tcl/8.5.19/tk8519-src.zip",
+        "url": GITHUB_DEPENDS_URL + "tk8519-src.zip",
         "filename": PILLOW_DEPENDS_DIR + "tk8519-src.zip",
         "dir": "",
         "version": "8.5.19",
     },
     "tcl-8.6": {
-        "url": SF_MIRROR + "/project/tcl/Tcl/8.6.9/tcl869-src.zip",
+        "url": GITHUB_DEPENDS_URL + "tcl869-src.zip",
         "filename": PILLOW_DEPENDS_DIR + "tcl869-src.zip",
         "dir": "",
     },
     "tk-8.6": {
-        "url": SF_MIRROR + "/project/tcl/Tcl/8.6.9/tk869-src.zip",
+        "url": GITHUB_DEPENDS_URL + "tk869-src.zip",
         "filename": PILLOW_DEPENDS_DIR + "tk869-src.zip",
         "dir": "",
         "version": "8.6.9",


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

 *  Port of https://github.com/python-pillow/Pillow/pull/5567 to fix CVE-2021-34552
 * Set the --disable-jpeg2000 flag to avoid CVE-2021-25287, CVE-2021-25288, CVE-2020-10994
 * Fix up some routes for downloading dependencies
 * Turn off building of versions that we don't require.
